### PR TITLE
Install specific nr types to avoid module not found error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cffi>=1.11.5
-nr.types>=1.0.3
+nr.types==1.0.3
 six>=1.11.0


### PR DESCRIPTION
Fixes #76 